### PR TITLE
Implement CRUD API endpoints

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,0 +1,13 @@
+from collections.abc import Generator
+
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+from .endpoints import accounts, sites, sync_jobs, users
+
+
+api_router = APIRouter()
+api_router.include_router(users.router, prefix="/users", tags=["users"])
+api_router.include_router(accounts.router, prefix="/accounts", tags=["accounts"])
+api_router.include_router(sites.router, prefix="/sites", tags=["sites"])
+api_router.include_router(sync_jobs.router, prefix="/sync-jobs", tags=["sync-jobs"])
+
+
+__all__ = ["api_router"]

--- a/app/api/v1/endpoints/accounts.py
+++ b/app/api/v1/endpoints/accounts.py
@@ -1,0 +1,61 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.api import deps
+from app.schemas.account import Account, AccountCreate, AccountUpdate
+
+
+router = APIRouter()
+
+
+@router.post("/", response_model=Account, status_code=status.HTTP_201_CREATED)
+def create_account(
+    *, db: Session = Depends(deps.get_db), account_in: AccountCreate
+) -> Account:
+    owner = crud.user.get(db, user_id=account_in.user_id)
+    if not owner:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return crud.account.create(db, obj_in=account_in)
+
+
+@router.get("/", response_model=List[Account])
+def read_accounts(
+    *,
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    user_id: Optional[int] = None,
+) -> List[Account]:
+    return crud.account.get_multi(db, skip=skip, limit=limit, user_id=user_id)
+
+
+@router.get("/{account_id}", response_model=Account)
+def read_account(*, db: Session = Depends(deps.get_db), account_id: int) -> Account:
+    db_account = crud.account.get(db, account_id=account_id)
+    if not db_account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return db_account
+
+
+@router.put("/{account_id}", response_model=Account)
+def update_account(
+    *,
+    db: Session = Depends(deps.get_db),
+    account_id: int,
+    account_in: AccountUpdate,
+) -> Account:
+    db_account = crud.account.get(db, account_id=account_id)
+    if not db_account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return crud.account.update(db, db_obj=db_account, obj_in=account_in)
+
+
+@router.delete("/{account_id}", response_model=Account)
+def delete_account(*, db: Session = Depends(deps.get_db), account_id: int) -> Account:
+    db_account = crud.account.get(db, account_id=account_id)
+    if not db_account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return crud.account.remove(db, db_obj=db_account)

--- a/app/api/v1/endpoints/sites.py
+++ b/app/api/v1/endpoints/sites.py
@@ -1,0 +1,66 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.api import deps
+from app.schemas.site import Site, SiteCreate, SiteUpdate
+
+
+router = APIRouter()
+
+
+@router.post("/", response_model=Site, status_code=status.HTTP_201_CREATED)
+def create_site(*, db: Session = Depends(deps.get_db), site_in: SiteCreate) -> Site:
+    account = crud.account.get(db, account_id=site_in.account_id)
+    if not account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return crud.site.create(db, obj_in=site_in)
+
+
+@router.get("/", response_model=List[Site])
+def read_sites(
+    *,
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    account_id: Optional[int] = None,
+    enabled: Optional[bool] = None,
+) -> List[Site]:
+    return crud.site.get_multi(
+        db,
+        skip=skip,
+        limit=limit,
+        account_id=account_id,
+        enabled=enabled,
+    )
+
+
+@router.get("/{site_id}", response_model=Site)
+def read_site(*, db: Session = Depends(deps.get_db), site_id: int) -> Site:
+    db_site = crud.site.get(db, site_id=site_id)
+    if not db_site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site not found")
+    return db_site
+
+
+@router.put("/{site_id}", response_model=Site)
+def update_site(
+    *,
+    db: Session = Depends(deps.get_db),
+    site_id: int,
+    site_in: SiteUpdate,
+) -> Site:
+    db_site = crud.site.get(db, site_id=site_id)
+    if not db_site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site not found")
+    return crud.site.update(db, db_obj=db_site, obj_in=site_in)
+
+
+@router.delete("/{site_id}", response_model=Site)
+def delete_site(*, db: Session = Depends(deps.get_db), site_id: int) -> Site:
+    db_site = crud.site.get(db, site_id=site_id)
+    if not db_site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site not found")
+    return crud.site.remove(db, db_obj=db_site)

--- a/app/api/v1/endpoints/sync_jobs.py
+++ b/app/api/v1/endpoints/sync_jobs.py
@@ -1,0 +1,68 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.api import deps
+from app.schemas.sync_job import SyncJob, SyncJobCreate, SyncJobUpdate
+
+
+router = APIRouter()
+
+
+@router.post("/", response_model=SyncJob, status_code=status.HTTP_201_CREATED)
+def create_sync_job(
+    *, db: Session = Depends(deps.get_db), sync_job_in: SyncJobCreate
+) -> SyncJob:
+    site = crud.site.get(db, site_id=sync_job_in.site_id)
+    if not site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site not found")
+    return crud.sync_job.create(db, obj_in=sync_job_in)
+
+
+@router.get("/", response_model=List[SyncJob])
+def read_sync_jobs(
+    *,
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    site_id: Optional[int] = None,
+    status_filter: Optional[str] = None,
+) -> List[SyncJob]:
+    return crud.sync_job.get_multi(
+        db,
+        skip=skip,
+        limit=limit,
+        site_id=site_id,
+        status=status_filter,
+    )
+
+
+@router.get("/{sync_job_id}", response_model=SyncJob)
+def read_sync_job(*, db: Session = Depends(deps.get_db), sync_job_id: int) -> SyncJob:
+    db_sync_job = crud.sync_job.get(db, sync_job_id=sync_job_id)
+    if not db_sync_job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sync job not found")
+    return db_sync_job
+
+
+@router.put("/{sync_job_id}", response_model=SyncJob)
+def update_sync_job(
+    *,
+    db: Session = Depends(deps.get_db),
+    sync_job_id: int,
+    sync_job_in: SyncJobUpdate,
+) -> SyncJob:
+    db_sync_job = crud.sync_job.get(db, sync_job_id=sync_job_id)
+    if not db_sync_job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sync job not found")
+    return crud.sync_job.update(db, db_obj=db_sync_job, obj_in=sync_job_in)
+
+
+@router.delete("/{sync_job_id}", response_model=SyncJob)
+def delete_sync_job(*, db: Session = Depends(deps.get_db), sync_job_id: int) -> SyncJob:
+    db_sync_job = crud.sync_job.get(db, sync_job_id=sync_job_id)
+    if not db_sync_job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sync job not found")
+    return crud.sync_job.remove(db, db_obj=db_sync_job)

--- a/app/api/v1/endpoints/users.py
+++ b/app/api/v1/endpoints/users.py
@@ -1,0 +1,68 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.api import deps
+from app.schemas.user import User, UserCreate, UserUpdate
+
+
+router = APIRouter()
+
+
+@router.post("/", response_model=User, status_code=status.HTTP_201_CREATED)
+def create_user(*, db: Session = Depends(deps.get_db), user_in: UserCreate) -> User:
+    existing_user = crud.user.get_by_email(db, email=user_in.email)
+    if existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email already registered",
+        )
+    return crud.user.create(db, obj_in=user_in)
+
+
+@router.get("/", response_model=List[User])
+def read_users(
+    *,
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+) -> List[User]:
+    return crud.user.get_multi(db, skip=skip, limit=limit)
+
+
+@router.get("/{user_id}", response_model=User)
+def read_user(*, db: Session = Depends(deps.get_db), user_id: int) -> User:
+    db_user = crud.user.get(db, user_id=user_id)
+    if not db_user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return db_user
+
+
+@router.put("/{user_id}", response_model=User)
+def update_user(
+    *,
+    db: Session = Depends(deps.get_db),
+    user_id: int,
+    user_in: UserUpdate,
+) -> User:
+    db_user = crud.user.get(db, user_id=user_id)
+    if not db_user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    if user_in.email and user_in.email != db_user.email:
+        existing_user = crud.user.get_by_email(db, email=user_in.email)
+        if existing_user:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Email already registered",
+            )
+    return crud.user.update(db, db_obj=db_user, obj_in=user_in)
+
+
+@router.delete("/{user_id}", response_model=User)
+def delete_user(*, db: Session = Depends(deps.get_db), user_id: int) -> User:
+    db_user = crud.user.get(db, user_id=user_id)
+    if not db_user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return crud.user.remove(db, db_obj=db_user)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,0 +1,14 @@
+from passlib.context import CryptContext
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a plaintext password against a stored hash."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    """Hash a plaintext password for storage."""
+    return pwd_context.hash(password)

--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,0 +1,6 @@
+from .account import account
+from .site import site
+from .sync_job import sync_job
+from .user import user
+
+__all__ = ["account", "site", "sync_job", "user"]

--- a/app/crud/account.py
+++ b/app/crud/account.py
@@ -1,0 +1,47 @@
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.account import Account
+from app.schemas.account import AccountCreate, AccountUpdate
+
+
+class CRUDAccount:
+    def get(self, db: Session, account_id: int) -> Optional[Account]:
+        return db.query(Account).filter(Account.id == account_id).first()
+
+    def get_multi(
+        self, db: Session, *, skip: int = 0, limit: int = 100, user_id: Optional[int] = None
+    ) -> List[Account]:
+        query = db.query(Account)
+        if user_id is not None:
+            query = query.filter(Account.user_id == user_id)
+        return query.offset(skip).limit(limit).all()
+
+    def create(self, db: Session, *, obj_in: AccountCreate) -> Account:
+        db_obj = Account(
+            user_id=obj_in.user_id,
+            provider=obj_in.provider,
+            credentials=obj_in.credentials,
+        )
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def update(self, db: Session, *, db_obj: Account, obj_in: AccountUpdate) -> Account:
+        update_data = obj_in.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def remove(self, db: Session, *, db_obj: Account) -> Account:
+        db.delete(db_obj)
+        db.commit()
+        return db_obj
+
+
+account = CRUDAccount()

--- a/app/crud/site.py
+++ b/app/crud/site.py
@@ -1,0 +1,55 @@
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.site import Site
+from app.schemas.site import SiteCreate, SiteUpdate
+
+
+class CRUDSite:
+    def get(self, db: Session, site_id: int) -> Optional[Site]:
+        return db.query(Site).filter(Site.id == site_id).first()
+
+    def get_multi(
+        self,
+        db: Session,
+        *,
+        skip: int = 0,
+        limit: int = 100,
+        account_id: Optional[int] = None,
+        enabled: Optional[bool] = None,
+    ) -> List[Site]:
+        query = db.query(Site)
+        if account_id is not None:
+            query = query.filter(Site.account_id == account_id)
+        if enabled is not None:
+            query = query.filter(Site.enabled == enabled)
+        return query.offset(skip).limit(limit).all()
+
+    def create(self, db: Session, *, obj_in: SiteCreate) -> Site:
+        db_obj = Site(
+            account_id=obj_in.account_id,
+            site_url=obj_in.site_url,
+            enabled=obj_in.enabled,
+        )
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def update(self, db: Session, *, db_obj: Site, obj_in: SiteUpdate) -> Site:
+        update_data = obj_in.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def remove(self, db: Session, *, db_obj: Site) -> Site:
+        db.delete(db_obj)
+        db.commit()
+        return db_obj
+
+
+site = CRUDSite()

--- a/app/crud/sync_job.py
+++ b/app/crud/sync_job.py
@@ -1,0 +1,51 @@
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.sync_job import SyncJob
+from app.schemas.sync_job import SyncJobCreate, SyncJobUpdate
+
+
+class CRUDSyncJob:
+    def get(self, db: Session, sync_job_id: int) -> Optional[SyncJob]:
+        return db.query(SyncJob).filter(SyncJob.id == sync_job_id).first()
+
+    def get_multi(
+        self,
+        db: Session,
+        *,
+        skip: int = 0,
+        limit: int = 100,
+        site_id: Optional[int] = None,
+        status: Optional[str] = None,
+    ) -> List[SyncJob]:
+        query = db.query(SyncJob)
+        if site_id is not None:
+            query = query.filter(SyncJob.site_id == site_id)
+        if status is not None:
+            query = query.filter(SyncJob.status == status)
+        return query.offset(skip).limit(limit).all()
+
+    def create(self, db: Session, *, obj_in: SyncJobCreate) -> SyncJob:
+        db_obj = SyncJob(**obj_in.model_dump())
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def update(self, db: Session, *, db_obj: SyncJob, obj_in: SyncJobUpdate) -> SyncJob:
+        update_data = obj_in.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def remove(self, db: Session, *, db_obj: SyncJob) -> SyncJob:
+        db.delete(db_obj)
+        db.commit()
+        return db_obj
+
+
+sync_job = CRUDSyncJob()

--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -1,0 +1,47 @@
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.security import get_password_hash
+from app.models.user import User
+from app.schemas.user import UserCreate, UserUpdate
+
+
+class CRUDUser:
+    def get(self, db: Session, user_id: int) -> Optional[User]:
+        return db.query(User).filter(User.id == user_id).first()
+
+    def get_by_email(self, db: Session, email: str) -> Optional[User]:
+        return db.query(User).filter(User.email == email).first()
+
+    def get_multi(self, db: Session, skip: int = 0, limit: int = 100) -> List[User]:
+        return db.query(User).offset(skip).limit(limit).all()
+
+    def create(self, db: Session, *, obj_in: UserCreate) -> User:
+        db_obj = User(
+            email=obj_in.email,
+            password_hash=get_password_hash(obj_in.password),
+        )
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def update(self, db: Session, *, db_obj: User, obj_in: UserUpdate) -> User:
+        update_data = obj_in.model_dump(exclude_unset=True)
+        if "password" in update_data:
+            db_obj.password_hash = get_password_hash(update_data.pop("password"))
+        if "email" in update_data:
+            db_obj.email = update_data["email"]
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def remove(self, db: Session, *, db_obj: User) -> User:
+        db.delete(db_obj)
+        db.commit()
+        return db_obj
+
+
+user = CRUDUser()

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -3,5 +3,17 @@ from sqlalchemy.orm import sessionmaker
 
 from app.core.config import settings
 
-engine = create_engine(settings.DATABASE_URL, pool_pre_ping=True)
+
+def _get_engine():
+    connect_args = {}
+    if settings.DATABASE_URL.startswith("sqlite"):
+        connect_args["check_same_thread"] = False
+    return create_engine(
+        settings.DATABASE_URL,
+        pool_pre_ping=True,
+        connect_args=connect_args,
+    )
+
+
+engine = _get_engine()
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,17 @@
 from fastapi import FastAPI
+
+from app.api.v1 import api_router as api_v1_router
 from app.core.config import settings
 
 app = FastAPI(title=settings.PROJECT_NAME)
 
+app.include_router(api_v1_router, prefix="/api/v1")
+
+
 @app.get("/")
 def read_root():
     return {"message": f"Welcome to {settings.PROJECT_NAME}"}
+
 
 @app.get("/health")
 def health_check():

--- a/app/schemas/account.py
+++ b/app/schemas/account.py
@@ -1,13 +1,26 @@
+from typing import Optional
+
 from pydantic import BaseModel
+
 
 class AccountBase(BaseModel):
     provider: str
 
+
 class AccountCreate(AccountBase):
     credentials: dict
+    user_id: int
+
+
+class AccountUpdate(BaseModel):
+    provider: Optional[str] = None
+    credentials: Optional[dict] = None
+
 
 class Account(AccountBase):
     id: int
+    user_id: int
+    credentials: dict
 
     class Config:
         orm_mode = True

--- a/app/schemas/site.py
+++ b/app/schemas/site.py
@@ -1,14 +1,25 @@
+from typing import Optional
+
 from pydantic import BaseModel
+
 
 class SiteBase(BaseModel):
     site_url: str
     enabled: bool = True
 
+
 class SiteCreate(SiteBase):
-    pass
+    account_id: int
+
+
+class SiteUpdate(BaseModel):
+    site_url: Optional[str] = None
+    enabled: Optional[bool] = None
+
 
 class Site(SiteBase):
     id: int
+    account_id: int
 
     class Config:
         orm_mode = True

--- a/app/schemas/sync_job.py
+++ b/app/schemas/sync_job.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class SyncJobBase(BaseModel):
+    site_id: int
+    status: Optional[str] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    error: Optional[str] = None
+
+
+class SyncJobCreate(SyncJobBase):
+    pass
+
+
+class SyncJobUpdate(BaseModel):
+    status: Optional[str] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    error: Optional[str] = None
+
+
+class SyncJob(SyncJobBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel, EmailStr
 
 class UserBase(BaseModel):
@@ -5,6 +7,12 @@ class UserBase(BaseModel):
 
 class UserCreate(UserBase):
     password: str
+
+
+class UserUpdate(BaseModel):
+    email: Optional[EmailStr] = None
+    password: Optional[str] = None
+
 
 class User(UserBase):
     id: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ celery
 redis
 pydantic[email]
 pydantic-settings
+passlib[bcrypt]
+pytest
+httpx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,67 @@
+import os
+import sys
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app.api.deps import get_db
+from app.core.config import settings
+from app.db.base_class import Base
+from app.db.session import engine
+from app.main import app as fastapi_app
+
+import app.models.account  # noqa: F401
+import app.models.search_data  # noqa: F401
+import app.models.site  # noqa: F401
+import app.models.sync_job  # noqa: F401
+import app.models.user  # noqa: F401
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False)
+
+
+@pytest.fixture(scope="session")
+def db_engine():
+    Base.metadata.create_all(bind=engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+    if settings.DATABASE_URL.startswith("sqlite"):
+        db_file = settings.DATABASE_URL.replace("sqlite:///", "")
+        if db_file:
+            Path(db_file).unlink(missing_ok=True)
+
+
+@pytest.fixture(scope="function")
+def db_session(db_engine) -> Generator:
+    connection = db_engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    try:
+        yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+
+
+@pytest.fixture(scope="function")
+def client(db_session):
+    def _get_test_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    fastapi_app.dependency_overrides[get_db] = _get_test_db
+    with TestClient(fastapi_app) as test_client:
+        yield test_client
+    fastapi_app.dependency_overrides.pop(get_db, None)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,128 @@
+from datetime import datetime, timezone
+
+
+def test_user_crud_flow(client):
+    response = client.post(
+        "/api/v1/users/",
+        json={"email": "user@example.com", "password": "secret"},
+    )
+    assert response.status_code == 201
+    user = response.json()
+    assert user["email"] == "user@example.com"
+
+    list_response = client.get("/api/v1/users/")
+    assert list_response.status_code == 200
+    users = list_response.json()
+    assert len(users) == 1
+
+    detail_response = client.get(f"/api/v1/users/{user['id']}")
+    assert detail_response.status_code == 200
+
+    update_response = client.put(
+        f"/api/v1/users/{user['id']}",
+        json={"email": "updated@example.com"},
+    )
+    assert update_response.status_code == 200
+    updated_user = update_response.json()
+    assert updated_user["email"] == "updated@example.com"
+
+    delete_response = client.delete(f"/api/v1/users/{user['id']}")
+    assert delete_response.status_code == 200
+
+
+def test_account_crud_flow(client):
+    user = client.post(
+        "/api/v1/users/",
+        json={"email": "owner@example.com", "password": "secret"},
+    ).json()
+
+    create_response = client.post(
+        "/api/v1/accounts/",
+        json={
+            "user_id": user["id"],
+            "provider": "google",
+            "credentials": {"token": "abc"},
+        },
+    )
+    assert create_response.status_code == 201
+    account = create_response.json()
+    assert account["provider"] == "google"
+    assert account["user_id"] == user["id"]
+
+    list_response = client.get(f"/api/v1/accounts/?user_id={user['id']}")
+    assert list_response.status_code == 200
+    accounts = list_response.json()
+    assert len(accounts) == 1
+
+    update_response = client.put(
+        f"/api/v1/accounts/{account['id']}",
+        json={"provider": "bing"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["provider"] == "bing"
+
+    delete_response = client.delete(f"/api/v1/accounts/{account['id']}")
+    assert delete_response.status_code == 200
+
+
+def test_site_and_sync_job_crud_flow(client):
+    user = client.post(
+        "/api/v1/users/",
+        json={"email": "sync@example.com", "password": "secret"},
+    ).json()
+    account = client.post(
+        "/api/v1/accounts/",
+        json={
+            "user_id": user["id"],
+            "provider": "google",
+            "credentials": {"token": "xyz"},
+        },
+    ).json()
+
+    site_response = client.post(
+        "/api/v1/sites/",
+        json={"account_id": account["id"], "site_url": "https://example.com"},
+    )
+    assert site_response.status_code == 201
+    site = site_response.json()
+    assert site["site_url"] == "https://example.com"
+
+    sites_response = client.get(f"/api/v1/sites/?account_id={account['id']}")
+    assert sites_response.status_code == 200
+    assert len(sites_response.json()) == 1
+
+    site_update = client.put(
+        f"/api/v1/sites/{site['id']}",
+        json={"enabled": False},
+    )
+    assert site_update.status_code == 200
+    assert site_update.json()["enabled"] is False
+
+    sync_job_response = client.post(
+        "/api/v1/sync-jobs/",
+        json={
+            "site_id": site["id"],
+            "status": "pending",
+            "started_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    assert sync_job_response.status_code == 201
+    sync_job = sync_job_response.json()
+    assert sync_job["status"] == "pending"
+
+    sync_jobs_response = client.get("/api/v1/sync-jobs/?status_filter=pending")
+    assert sync_jobs_response.status_code == 200
+    assert len(sync_jobs_response.json()) == 1
+
+    sync_job_update = client.put(
+        f"/api/v1/sync-jobs/{sync_job['id']}",
+        json={"status": "completed"},
+    )
+    assert sync_job_update.status_code == 200
+    assert sync_job_update.json()["status"] == "completed"
+
+    sync_job_delete = client.delete(f"/api/v1/sync-jobs/{sync_job['id']}")
+    assert sync_job_delete.status_code == 200
+
+    site_delete = client.delete(f"/api/v1/sites/{site['id']}")
+    assert site_delete.status_code == 200


### PR DESCRIPTION
## Summary
- add CRUD services, Pydantic schemas, and FastAPI routers for users, accounts, sites, and sync jobs
- secure user creation with hashed passwords and expose a reusable database dependency
- expand project requirements and test support with new dependencies and pytest coverage for API flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfc56b0cf08325b161820a7a25bb5c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced versioned API at /api/v1 with full CRUD for Users, Accounts, Sites, and Sync Jobs.
  - Supports pagination and filtering across list endpoints.
  - Consistent error responses for not-found and conflicts.
  - Passwords are now stored securely (hashed).
  - API updates: Account creation requires a user reference; Site creation requires an account reference; partial updates supported for users, sites, accounts, and sync jobs.

- Tests
  - Added comprehensive end-to-end tests covering all new API flows.

- Chores
  - Added dependencies: passlib[bcrypt], pytest, httpx.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->