### PR TITLE
Normalize account providers and validate supported types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# SEO Data Sync Platform
+
+This project provides a FastAPI-based backend for managing search console
+integrations and scheduled data syncs.  Celery is used to coordinate both the
+historical backfill and the daily incremental sync jobs for each site.
+
+## Running the application
+
+1.  Install dependencies:
+
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+2.  Start the FastAPI server:
+
+    ```bash
+    uvicorn app.main:app --reload
+    ```
+
+The API expects an `ENCRYPTION_KEY` environment variable containing a
+base64-encoded Fernet key. A development-safe default is provided, but you
+should generate a unique value for any deployed environment:
+
+```bash
+python - <<'PY'
+import base64, os
+print(base64.urlsafe_b64encode(os.urandom(32)).decode())
+PY
+```
+
+Set the resulting value before starting the API, worker, or tests:
+
+```bash
+export ENCRYPTION_KEY="<generated-key>"
+```
+
+## Background workers
+
+Celery powers the asynchronous processing pipeline.  Two processes are required
+in development:
+
+- **Worker:** Executes queued backfill and daily sync tasks.
+- **Beat:** Enqueues the `run_daily_sync` task for every enabled site once per
+  day based on the configured schedule.
+
+Start them with:
+
+```bash
+celery -A workers.celery_app worker --loglevel=info
+celery -A workers.celery_app beat --loglevel=info
+```
+
+The schedule is rebuilt automatically when the beat process starts, but it can
+also be refreshed manually:
+
+```bash
+python -m workers.cli refresh-schedule
+```
+
+## Triggering jobs manually
+
+A small CLI wrapper is available for local workflows.
+
+```bash
+python -m workers.cli backfill <site_id>
+python -m workers.cli sync <site_id>
+```
+
+Both commands enqueue Celery tasks, so make sure the worker process is running.

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,0 +1,13 @@
+from collections.abc import Generator
+
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+from .endpoints import accounts, sites, sync_jobs, users
+
+
+api_router = APIRouter()
+api_router.include_router(users.router, prefix="/users", tags=["users"])
+api_router.include_router(accounts.router, prefix="/accounts", tags=["accounts"])
+api_router.include_router(sites.router, prefix="/sites", tags=["sites"])
+api_router.include_router(sync_jobs.router, prefix="/sync-jobs", tags=["sync-jobs"])
+
+
+__all__ = ["api_router"]

--- a/app/api/v1/endpoints/accounts.py
+++ b/app/api/v1/endpoints/accounts.py
@@ -1,0 +1,61 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.api import deps
+from app.schemas.account import Account, AccountCreate, AccountUpdate
+
+
+router = APIRouter()
+
+
+@router.post("/", response_model=Account, status_code=status.HTTP_201_CREATED)
+def create_account(
+    *, db: Session = Depends(deps.get_db), account_in: AccountCreate
+) -> Account:
+    owner = crud.user.get(db, user_id=account_in.user_id)
+    if not owner:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return crud.account.create(db, obj_in=account_in)
+
+
+@router.get("/", response_model=List[Account])
+def read_accounts(
+    *,
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    user_id: Optional[int] = None,
+) -> List[Account]:
+    return crud.account.get_multi(db, skip=skip, limit=limit, user_id=user_id)
+
+
+@router.get("/{account_id}", response_model=Account)
+def read_account(*, db: Session = Depends(deps.get_db), account_id: int) -> Account:
+    db_account = crud.account.get(db, account_id=account_id)
+    if not db_account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return db_account
+
+
+@router.put("/{account_id}", response_model=Account)
+def update_account(
+    *,
+    db: Session = Depends(deps.get_db),
+    account_id: int,
+    account_in: AccountUpdate,
+) -> Account:
+    db_account = crud.account.get(db, account_id=account_id)
+    if not db_account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return crud.account.update(db, db_obj=db_account, obj_in=account_in)
+
+
+@router.delete("/{account_id}", response_model=Account)
+def delete_account(*, db: Session = Depends(deps.get_db), account_id: int) -> Account:
+    db_account = crud.account.get(db, account_id=account_id)
+    if not db_account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return crud.account.remove(db, db_obj=db_account)

--- a/app/api/v1/endpoints/sites.py
+++ b/app/api/v1/endpoints/sites.py
@@ -1,0 +1,66 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.api import deps
+from app.schemas.site import Site, SiteCreate, SiteUpdate
+
+
+router = APIRouter()
+
+
+@router.post("/", response_model=Site, status_code=status.HTTP_201_CREATED)
+def create_site(*, db: Session = Depends(deps.get_db), site_in: SiteCreate) -> Site:
+    account = crud.account.get(db, account_id=site_in.account_id)
+    if not account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return crud.site.create(db, obj_in=site_in)
+
+
+@router.get("/", response_model=List[Site])
+def read_sites(
+    *,
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    account_id: Optional[int] = None,
+    enabled: Optional[bool] = None,
+) -> List[Site]:
+    return crud.site.get_multi(
+        db,
+        skip=skip,
+        limit=limit,
+        account_id=account_id,
+        enabled=enabled,
+    )
+
+
+@router.get("/{site_id}", response_model=Site)
+def read_site(*, db: Session = Depends(deps.get_db), site_id: int) -> Site:
+    db_site = crud.site.get(db, site_id=site_id)
+    if not db_site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site not found")
+    return db_site
+
+
+@router.put("/{site_id}", response_model=Site)
+def update_site(
+    *,
+    db: Session = Depends(deps.get_db),
+    site_id: int,
+    site_in: SiteUpdate,
+) -> Site:
+    db_site = crud.site.get(db, site_id=site_id)
+    if not db_site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site not found")
+    return crud.site.update(db, db_obj=db_site, obj_in=site_in)
+
+
+@router.delete("/{site_id}", response_model=Site)
+def delete_site(*, db: Session = Depends(deps.get_db), site_id: int) -> Site:
+    db_site = crud.site.get(db, site_id=site_id)
+    if not db_site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site not found")
+    return crud.site.remove(db, db_obj=db_site)

--- a/app/api/v1/endpoints/sync_jobs.py
+++ b/app/api/v1/endpoints/sync_jobs.py
@@ -1,0 +1,68 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.api import deps
+from app.schemas.sync_job import SyncJob, SyncJobCreate, SyncJobUpdate
+
+
+router = APIRouter()
+
+
+@router.post("/", response_model=SyncJob, status_code=status.HTTP_201_CREATED)
+def create_sync_job(
+    *, db: Session = Depends(deps.get_db), sync_job_in: SyncJobCreate
+) -> SyncJob:
+    site = crud.site.get(db, site_id=sync_job_in.site_id)
+    if not site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site not found")
+    return crud.sync_job.create(db, obj_in=sync_job_in)
+
+
+@router.get("/", response_model=List[SyncJob])
+def read_sync_jobs(
+    *,
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+    site_id: Optional[int] = None,
+    status_filter: Optional[str] = None,
+) -> List[SyncJob]:
+    return crud.sync_job.get_multi(
+        db,
+        skip=skip,
+        limit=limit,
+        site_id=site_id,
+        status=status_filter,
+    )
+
+
+@router.get("/{sync_job_id}", response_model=SyncJob)
+def read_sync_job(*, db: Session = Depends(deps.get_db), sync_job_id: int) -> SyncJob:
+    db_sync_job = crud.sync_job.get(db, sync_job_id=sync_job_id)
+    if not db_sync_job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sync job not found")
+    return db_sync_job
+
+
+@router.put("/{sync_job_id}", response_model=SyncJob)
+def update_sync_job(
+    *,
+    db: Session = Depends(deps.get_db),
+    sync_job_id: int,
+    sync_job_in: SyncJobUpdate,
+) -> SyncJob:
+    db_sync_job = crud.sync_job.get(db, sync_job_id=sync_job_id)
+    if not db_sync_job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sync job not found")
+    return crud.sync_job.update(db, db_obj=db_sync_job, obj_in=sync_job_in)
+
+
+@router.delete("/{sync_job_id}", response_model=SyncJob)
+def delete_sync_job(*, db: Session = Depends(deps.get_db), sync_job_id: int) -> SyncJob:
+    db_sync_job = crud.sync_job.get(db, sync_job_id=sync_job_id)
+    if not db_sync_job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sync job not found")
+    return crud.sync_job.remove(db, db_obj=db_sync_job)

--- a/app/api/v1/endpoints/users.py
+++ b/app/api/v1/endpoints/users.py
@@ -1,0 +1,68 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import crud
+from app.api import deps
+from app.schemas.user import User, UserCreate, UserUpdate
+
+
+router = APIRouter()
+
+
+@router.post("/", response_model=User, status_code=status.HTTP_201_CREATED)
+def create_user(*, db: Session = Depends(deps.get_db), user_in: UserCreate) -> User:
+    existing_user = crud.user.get_by_email(db, email=user_in.email)
+    if existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email already registered",
+        )
+    return crud.user.create(db, obj_in=user_in)
+
+
+@router.get("/", response_model=List[User])
+def read_users(
+    *,
+    db: Session = Depends(deps.get_db),
+    skip: int = 0,
+    limit: int = 100,
+) -> List[User]:
+    return crud.user.get_multi(db, skip=skip, limit=limit)
+
+
+@router.get("/{user_id}", response_model=User)
+def read_user(*, db: Session = Depends(deps.get_db), user_id: int) -> User:
+    db_user = crud.user.get(db, user_id=user_id)
+    if not db_user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return db_user
+
+
+@router.put("/{user_id}", response_model=User)
+def update_user(
+    *,
+    db: Session = Depends(deps.get_db),
+    user_id: int,
+    user_in: UserUpdate,
+) -> User:
+    db_user = crud.user.get(db, user_id=user_id)
+    if not db_user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    if user_in.email and user_in.email != db_user.email:
+        existing_user = crud.user.get_by_email(db, email=user_in.email)
+        if existing_user:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Email already registered",
+            )
+    return crud.user.update(db, db_obj=db_user, obj_in=user_in)
+
+
+@router.delete("/{user_id}", response_model=User)
+def delete_user(*, db: Session = Depends(deps.get_db), user_id: int) -> User:
+    db_user = crud.user.get(db, user_id=user_id)
+    if not db_user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return crud.user.remove(db, db_obj=db_user)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,4 +1,5 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
 
 class Settings(BaseSettings):
     PROJECT_NAME: str = "SEO Data Sync Platform"
@@ -7,8 +8,19 @@ class Settings(BaseSettings):
     # In a production environment, this should be set via an environment variable.
     DATABASE_URL: str = "postgresql://user:password@localhost/dbname"
 
-    class Config:
-        case_sensitive = True
-        env_file = ".env"
+    # Celery configuration defaults for local development. Override these values
+    # via environment variables in production deployments.
+    CELERY_BROKER_URL: str = "redis://localhost:6379/0"
+    CELERY_RESULT_BACKEND: str = "redis://localhost:6379/0"
+    CELERY_TIMEZONE: str = "UTC"
+    DAILY_SYNC_HOUR: int = 2
+    DAILY_SYNC_MINUTE: int = 0
+
+    # Symmetric encryption key used for protecting stored account credentials.
+    # This should be overridden with a secure value in production.
+    ENCRYPTION_KEY: str = "XdP2PVYDrU5oMxMl7LsFOR22fs-gWw1i4quG67aGlOg="
+
+    model_config = SettingsConfigDict(case_sensitive=True, env_file=".env")
+
 
 settings = Settings()

--- a/app/core/crypto.py
+++ b/app/core/crypto.py
@@ -1,0 +1,50 @@
+"""Helpers for encrypting and decrypting sensitive payloads."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from typing import Any, Mapping
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from app.core.config import settings
+
+
+class CredentialEncryptionError(RuntimeError):
+    """Raised when encrypted credentials cannot be decrypted."""
+
+
+@lru_cache(maxsize=1)
+def _get_fernet() -> Fernet:
+    """Return a cached ``Fernet`` instance using the configured key."""
+
+    key = settings.ENCRYPTION_KEY
+    if not key:
+        raise RuntimeError("ENCRYPTION_KEY must be configured")
+    if isinstance(key, str):
+        key_bytes = key.encode("utf-8")
+    else:
+        key_bytes = key
+    return Fernet(key_bytes)
+
+
+def encrypt_dict(payload: Mapping[str, Any]) -> str:
+    """Encrypt a dictionary payload using the configured Fernet key."""
+
+    serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    token = _get_fernet().encrypt(serialized.encode("utf-8"))
+    return token.decode("utf-8")
+
+
+def decrypt_dict(token: str) -> dict[str, Any]:
+    """Decrypt a previously encrypted payload into its dictionary form."""
+
+    try:
+        decrypted = _get_fernet().decrypt(token.encode("utf-8"))
+    except InvalidToken as exc:  # pragma: no cover - defensive guard
+        raise CredentialEncryptionError("Invalid credentials payload") from exc
+    return json.loads(decrypted.decode("utf-8"))
+
+
+__all__ = ["CredentialEncryptionError", "decrypt_dict", "encrypt_dict"]

--- a/app/core/providers.py
+++ b/app/core/providers.py
@@ -1,0 +1,20 @@
+"""Shared helpers for working with supported search providers."""
+
+from __future__ import annotations
+
+from typing import FrozenSet
+
+SUPPORTED_PROVIDERS: FrozenSet[str] = frozenset({"google", "bing"})
+
+
+def normalize_provider(value: str) -> str:
+    """Normalize a provider identifier and ensure it is supported."""
+
+    normalized = (value or "").strip().lower()
+    if normalized not in SUPPORTED_PROVIDERS:
+        allowed = ", ".join(sorted(SUPPORTED_PROVIDERS))
+        raise ValueError(f"Unsupported provider '{value}'. Expected one of: {allowed}.")
+    return normalized
+
+
+__all__ = ["SUPPORTED_PROVIDERS", "normalize_provider"]

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,0 +1,14 @@
+from passlib.context import CryptContext
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a plaintext password against a stored hash."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    """Hash a plaintext password for storage."""
+    return pwd_context.hash(password)

--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,0 +1,6 @@
+from .account import account
+from .site import site
+from .sync_job import sync_job
+from .user import user
+
+__all__ = ["account", "site", "sync_job", "user"]

--- a/app/crud/account.py
+++ b/app/crud/account.py
@@ -1,0 +1,47 @@
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.account import Account
+from app.schemas.account import AccountCreate, AccountUpdate
+
+
+class CRUDAccount:
+    def get(self, db: Session, account_id: int) -> Optional[Account]:
+        return db.query(Account).filter(Account.id == account_id).first()
+
+    def get_multi(
+        self, db: Session, *, skip: int = 0, limit: int = 100, user_id: Optional[int] = None
+    ) -> List[Account]:
+        query = db.query(Account)
+        if user_id is not None:
+            query = query.filter(Account.user_id == user_id)
+        return query.offset(skip).limit(limit).all()
+
+    def create(self, db: Session, *, obj_in: AccountCreate) -> Account:
+        db_obj = Account(
+            user_id=obj_in.user_id,
+            provider=obj_in.provider,
+            credentials=obj_in.credentials,
+        )
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def update(self, db: Session, *, db_obj: Account, obj_in: AccountUpdate) -> Account:
+        update_data = obj_in.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def remove(self, db: Session, *, db_obj: Account) -> Account:
+        db.delete(db_obj)
+        db.commit()
+        return db_obj
+
+
+account = CRUDAccount()

--- a/app/crud/site.py
+++ b/app/crud/site.py
@@ -1,0 +1,55 @@
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.site import Site
+from app.schemas.site import SiteCreate, SiteUpdate
+
+
+class CRUDSite:
+    def get(self, db: Session, site_id: int) -> Optional[Site]:
+        return db.query(Site).filter(Site.id == site_id).first()
+
+    def get_multi(
+        self,
+        db: Session,
+        *,
+        skip: int = 0,
+        limit: int = 100,
+        account_id: Optional[int] = None,
+        enabled: Optional[bool] = None,
+    ) -> List[Site]:
+        query = db.query(Site)
+        if account_id is not None:
+            query = query.filter(Site.account_id == account_id)
+        if enabled is not None:
+            query = query.filter(Site.enabled == enabled)
+        return query.offset(skip).limit(limit).all()
+
+    def create(self, db: Session, *, obj_in: SiteCreate) -> Site:
+        db_obj = Site(
+            account_id=obj_in.account_id,
+            site_url=obj_in.site_url,
+            enabled=obj_in.enabled,
+        )
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def update(self, db: Session, *, db_obj: Site, obj_in: SiteUpdate) -> Site:
+        update_data = obj_in.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def remove(self, db: Session, *, db_obj: Site) -> Site:
+        db.delete(db_obj)
+        db.commit()
+        return db_obj
+
+
+site = CRUDSite()

--- a/app/crud/sync_job.py
+++ b/app/crud/sync_job.py
@@ -1,0 +1,51 @@
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.sync_job import SyncJob
+from app.schemas.sync_job import SyncJobCreate, SyncJobUpdate
+
+
+class CRUDSyncJob:
+    def get(self, db: Session, sync_job_id: int) -> Optional[SyncJob]:
+        return db.query(SyncJob).filter(SyncJob.id == sync_job_id).first()
+
+    def get_multi(
+        self,
+        db: Session,
+        *,
+        skip: int = 0,
+        limit: int = 100,
+        site_id: Optional[int] = None,
+        status: Optional[str] = None,
+    ) -> List[SyncJob]:
+        query = db.query(SyncJob)
+        if site_id is not None:
+            query = query.filter(SyncJob.site_id == site_id)
+        if status is not None:
+            query = query.filter(SyncJob.status == status)
+        return query.offset(skip).limit(limit).all()
+
+    def create(self, db: Session, *, obj_in: SyncJobCreate) -> SyncJob:
+        db_obj = SyncJob(**obj_in.model_dump())
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def update(self, db: Session, *, db_obj: SyncJob, obj_in: SyncJobUpdate) -> SyncJob:
+        update_data = obj_in.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def remove(self, db: Session, *, db_obj: SyncJob) -> SyncJob:
+        db.delete(db_obj)
+        db.commit()
+        return db_obj
+
+
+sync_job = CRUDSyncJob()

--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -1,0 +1,47 @@
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.security import get_password_hash
+from app.models.user import User
+from app.schemas.user import UserCreate, UserUpdate
+
+
+class CRUDUser:
+    def get(self, db: Session, user_id: int) -> Optional[User]:
+        return db.query(User).filter(User.id == user_id).first()
+
+    def get_by_email(self, db: Session, email: str) -> Optional[User]:
+        return db.query(User).filter(User.email == email).first()
+
+    def get_multi(self, db: Session, skip: int = 0, limit: int = 100) -> List[User]:
+        return db.query(User).offset(skip).limit(limit).all()
+
+    def create(self, db: Session, *, obj_in: UserCreate) -> User:
+        db_obj = User(
+            email=obj_in.email,
+            password_hash=get_password_hash(obj_in.password),
+        )
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def update(self, db: Session, *, db_obj: User, obj_in: UserUpdate) -> User:
+        update_data = obj_in.model_dump(exclude_unset=True)
+        if "password" in update_data:
+            db_obj.password_hash = get_password_hash(update_data.pop("password"))
+        if "email" in update_data:
+            db_obj.email = update_data["email"]
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def remove(self, db: Session, *, db_obj: User) -> User:
+        db.delete(db_obj)
+        db.commit()
+        return db_obj
+
+
+user = CRUDUser()

--- a/app/db/schema.sql
+++ b/app/db/schema.sql
@@ -8,7 +8,7 @@ CREATE TABLE accounts (
   id SERIAL PRIMARY KEY,
   user_id INT REFERENCES users(id),
   provider TEXT CHECK (provider IN ('google', 'bing')),
-  credentials JSONB -- encrypted
+  credentials TEXT -- Fernet encrypted payload
 );
 
 CREATE TABLE sites (

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -3,5 +3,17 @@ from sqlalchemy.orm import sessionmaker
 
 from app.core.config import settings
 
-engine = create_engine(settings.DATABASE_URL, pool_pre_ping=True)
+
+def _get_engine():
+    connect_args = {}
+    if settings.DATABASE_URL.startswith("sqlite"):
+        connect_args["check_same_thread"] = False
+    return create_engine(
+        settings.DATABASE_URL,
+        pool_pre_ping=True,
+        connect_args=connect_args,
+    )
+
+
+engine = _get_engine()
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,17 @@
 from fastapi import FastAPI
+
+from app.api.v1 import api_router as api_v1_router
 from app.core.config import settings
 
 app = FastAPI(title=settings.PROJECT_NAME)
 
+app.include_router(api_v1_router, prefix="/api/v1")
+
+
 @app.get("/")
 def read_root():
     return {"message": f"Welcome to {settings.PROJECT_NAME}"}
+
 
 @app.get("/health")
 def health_check():

--- a/app/models/account.py
+++ b/app/models/account.py
@@ -1,14 +1,43 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, JSON
-from sqlalchemy.orm import relationship
+from typing import Any
+
+from sqlalchemy import Column, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship, synonym, validates
+
+from app.core.crypto import decrypt_dict, encrypt_dict
+from app.core.providers import normalize_provider
 
 from app.db.base_class import Base
 
 
 class Account(Base):
-    __tablename__ = 'accounts'
+    __tablename__ = "accounts"
+
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey('users.id'))
+    user_id = Column(Integer, ForeignKey("users.id"))
     provider = Column(String, nullable=False)
-    credentials = Column(JSON, nullable=False)
+    _credentials = Column("credentials", Text, nullable=False)
+
     owner = relationship("User", back_populates="accounts")
     sites = relationship("Site", back_populates="account")
+
+    @validates("provider")
+    def _validate_provider(self, _: str, value: str) -> str:
+        return normalize_provider(value)
+
+    def _get_credentials(self) -> dict[str, Any]:
+        raw = self._credentials
+        if raw is None:
+            return {}
+        if isinstance(raw, str):
+            return decrypt_dict(raw)
+        return raw
+
+    def _set_credentials(self, value: dict[str, Any] | str | None) -> None:
+        if value is None:
+            raise ValueError("Credentials cannot be null")
+        if isinstance(value, str):
+            self._credentials = value
+        else:
+            self._credentials = encrypt_dict(value)
+
+    credentials = synonym("_credentials", descriptor=property(_get_credentials, _set_credentials))

--- a/app/models/search_data.py
+++ b/app/models/search_data.py
@@ -1,10 +1,10 @@
-from sqlalchemy import Column, BigInteger, Integer, String, Date, Float, ForeignKey, UniqueConstraint
+from sqlalchemy import Column, Integer, String, Date, Float, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import relationship
 from app.db.base_class import Base
 
 class SearchData(Base):
     __tablename__ = 'search_data'
-    id = Column(BigInteger, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
     site_id = Column(Integer, ForeignKey('sites.id'))
     provider = Column(String, nullable=False)
     date = Column(Date, nullable=False)
@@ -16,4 +16,9 @@ class SearchData(Base):
     position = Column(Float)
     site = relationship("Site", back_populates="search_data")
 
-    __table_args__ = (UniqueConstraint('site_id', 'provider', 'date', 'dimension', 'key', name='_site_provider_date_dimension_key_uc'),)
+    __table_args__ = (
+        UniqueConstraint(
+            'site_id', 'provider', 'date', 'dimension', 'key', name='_site_provider_date_dimension_key_uc'
+        ),
+        {'sqlite_autoincrement': True},
+    )

--- a/app/schemas/account.py
+++ b/app/schemas/account.py
@@ -1,13 +1,39 @@
-from pydantic import BaseModel
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from app.core.providers import normalize_provider
+
 
 class AccountBase(BaseModel):
     provider: str
 
+    @field_validator("provider")
+    @classmethod
+    def _normalize_provider(cls, value: str) -> str:
+        return normalize_provider(value)
+
+
 class AccountCreate(AccountBase):
-    credentials: dict
+    credentials: dict[str, Any]
+    user_id: int
+
+
+class AccountUpdate(BaseModel):
+    provider: Optional[str] = None
+    credentials: Optional[dict[str, Any]] = None
+
+    @field_validator("provider")
+    @classmethod
+    def _normalize_optional_provider(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        return normalize_provider(value)
+
 
 class Account(AccountBase):
     id: int
+    user_id: int
+    credentials: dict[str, Any]
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/site.py
+++ b/app/schemas/site.py
@@ -1,14 +1,24 @@
-from pydantic import BaseModel
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
 
 class SiteBase(BaseModel):
     site_url: str
     enabled: bool = True
 
+
 class SiteCreate(SiteBase):
-    pass
+    account_id: int
+
+
+class SiteUpdate(BaseModel):
+    site_url: Optional[str] = None
+    enabled: Optional[bool] = None
+
 
 class Site(SiteBase):
     id: int
+    account_id: int
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/sync_job.py
+++ b/app/schemas/sync_job.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SyncJobBase(BaseModel):
+    site_id: int
+    status: Optional[str] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    error: Optional[str] = None
+
+
+class SyncJobCreate(SyncJobBase):
+    pass
+
+
+class SyncJobUpdate(BaseModel):
+    status: Optional[str] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    error: Optional[str] = None
+
+
+class SyncJob(SyncJobBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, EmailStr
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, EmailStr
 
 class UserBase(BaseModel):
     email: EmailStr
@@ -6,8 +8,13 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     password: str
 
+
+class UserUpdate(BaseModel):
+    email: Optional[EmailStr] = None
+    password: Optional[str] = None
+
+
 class User(UserBase):
     id: int
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,13 @@
+"""Service layer utilities for orchestrating data syncs."""
+
+from .bing_webmaster import BingWebmasterService
+from .google_search_console import GoogleSearchConsoleService
+from .sync_runner import SyncRunner
+from .types import SearchAnalyticsRow
+
+__all__ = [
+    "BingWebmasterService",
+    "GoogleSearchConsoleService",
+    "SearchAnalyticsRow",
+    "SyncRunner",
+]

--- a/app/services/bing_webmaster.py
+++ b/app/services/bing_webmaster.py
@@ -1,0 +1,171 @@
+"""Bing Webmaster Tools integration helpers."""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import date, timedelta
+from typing import Any, Iterable
+
+import httpx
+
+from app.services.types import SearchAnalyticsRow
+
+logger = logging.getLogger(__name__)
+
+RowList = list[SearchAnalyticsRow]
+
+
+class BingWebmasterService:
+    """Wrapper for Bing Webmaster Tools analytics endpoints."""
+
+    _BASE_URL = "https://api.bing.microsoft.com/v7.0/Webmaster"
+    _HISTORY_WINDOW_DAYS = 365
+
+    def __init__(
+        self,
+        credentials: dict[str, Any],
+        *,
+        client: httpx.Client | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        api_key = credentials.get("api_key") or credentials.get("key") or credentials.get("token")
+        if not api_key:
+            raise ValueError("Bing credentials must include an API key")
+        self._api_key = api_key
+        self._client = client or httpx.Client(timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def fetch_backfill(self, site_url: str, *, end_date: date | None = None) -> RowList:
+        end = end_date or (date.today() - timedelta(days=1))
+        start = end - timedelta(days=self._HISTORY_WINDOW_DAYS - 1)
+        return self._fetch_range(site_url, start, end)
+
+    def fetch_daily(self, site_url: str, run_date: date) -> RowList:
+        return self._fetch_range(site_url, run_date, run_date)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _fetch_range(self, site_url: str, start: date, end: date) -> RowList:
+        query_rows = self._request_with_retry("/QueryStats", site_url, start, end)
+        page_rows = self._request_with_retry("/PageStats", site_url, start, end)
+        rows: RowList = []
+        rows.extend(self._normalize(query_rows, dimension="query"))
+        rows.extend(self._normalize(page_rows, dimension="page"))
+        return rows
+
+    def _request_with_retry(
+        self, endpoint: str, site_url: str, start: date, end: date
+    ) -> dict[str, Any]:
+        attempt = 0
+        delay = 0.1
+        last_error: Exception | None = None
+        params = {
+            "siteUrl": site_url,
+            "startDate": start.isoformat(),
+            "endDate": end.isoformat(),
+        }
+        headers = {"Ocp-Apim-Subscription-Key": self._api_key}
+        while attempt < 3:
+            try:
+                response = self._client.get(
+                    f"{self._BASE_URL}{endpoint}",
+                    params=params,
+                    headers=headers,
+                )
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as exc:  # pragma: no cover - retried in tests
+                last_error = exc
+                logger.error(
+                    "Bing request failed",
+                    extra={
+                        "site": site_url,
+                        "status": exc.response.status_code,
+                        "body": exc.response.text,
+                        "attempt": attempt + 1,
+                        "endpoint": endpoint,
+                    },
+                )
+                attempt += 1
+                if attempt >= 3:
+                    raise
+                time.sleep(delay)
+                delay *= 2
+            except httpx.RequestError as exc:
+                last_error = exc
+                logger.error(
+                    "Bing transport error",
+                    extra={
+                        "site": site_url,
+                        "body": str(exc),
+                        "attempt": attempt + 1,
+                        "endpoint": endpoint,
+                    },
+                )
+                attempt += 1
+                if attempt >= 3:
+                    raise
+                time.sleep(delay)
+                delay *= 2
+        if last_error:
+            raise last_error
+        return {}
+
+    def _normalize(self, payload: dict[str, Any], *, dimension: str) -> RowList:
+        rows: RowList = []
+        items: Iterable[dict[str, Any]] = []
+        if isinstance(payload, dict):
+            if "value" in payload and isinstance(payload["value"], list):
+                items = payload["value"]
+            elif "d" in payload and isinstance(payload["d"], dict) and isinstance(
+                payload["d"].get("results"), list
+            ):
+                items = payload["d"]["results"]
+            elif dimension == "query" and isinstance(payload.get("queries"), list):
+                items = payload["queries"]
+            elif dimension == "page" and isinstance(payload.get("pages"), list):
+                items = payload["pages"]
+
+        for item in items:
+            date_str = (
+                item.get("date")
+                or item.get("Date")
+                or item.get("day")
+                or item.get("Day")
+            )
+            if not date_str:
+                continue
+            try:
+                row_date = date.fromisoformat(date_str[:10])
+            except ValueError:
+                logger.debug("Skipping Bing row with invalid date: %s", item)
+                continue
+            key = (
+                item.get("query")
+                or item.get("Query")
+                or item.get("page")
+                or item.get("Page")
+                or ""
+            )
+            rows.append(
+                SearchAnalyticsRow(
+                    date=row_date,
+                    dimension=dimension,
+                    key=key,
+                    clicks=int(item.get("clicks") or item.get("Clicks") or 0),
+                    impressions=int(item.get("impressions") or item.get("Impressions") or 0),
+                    ctr=float(item.get("ctr") or item.get("Ctr") or 0.0),
+                    position=float(item.get("position") or item.get("Position") or 0.0),
+                )
+            )
+        return rows
+
+    def close(self) -> None:
+        self._client.close()
+
+
+__all__ = ["BingWebmasterService"]

--- a/app/services/google_search_console.py
+++ b/app/services/google_search_console.py
@@ -1,0 +1,176 @@
+"""Google Search Console integration helpers."""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import date, timedelta
+from typing import Any, Callable, Iterable, Sequence
+
+from googleapiclient.errors import HttpError
+
+from app.services.types import SearchAnalyticsRow
+
+logger = logging.getLogger(__name__)
+
+RowList = list[SearchAnalyticsRow]
+
+
+class GoogleSearchConsoleService:
+    """Lightweight wrapper around the Search Console API."""
+
+    _HISTORY_WINDOW_DAYS = 16 * 31  # ~16 months
+
+    def __init__(
+        self,
+        credentials: dict[str, Any],
+        *,
+        client_factory: Callable[[], Any] | None = None,
+        row_limit: int = 25_000,
+    ) -> None:
+        self.credentials = credentials
+        self._client_factory = client_factory or self._default_client_factory
+        self._client: Any | None = None
+        self._row_limit = row_limit
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def fetch_backfill(self, site_url: str, *, end_date: date | None = None) -> RowList:
+        """Fetch the historical backfill window for the provided site."""
+
+        end = end_date or (date.today() - timedelta(days=1))
+        start = end - timedelta(days=self._HISTORY_WINDOW_DAYS - 1)
+        return self._fetch_range(site_url, start, end)
+
+    def fetch_daily(self, site_url: str, run_date: date) -> RowList:
+        """Fetch analytics for a specific date."""
+
+        return self._fetch_range(site_url, run_date, run_date)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _default_client_factory(self) -> Any:
+        from google.oauth2.credentials import Credentials
+        from googleapiclient.discovery import build
+
+        if "token" in self.credentials and "refresh_token" not in self.credentials:
+            # Support simple API key style credentials for testing environments.
+            return build(
+                "searchconsole",
+                "v1",
+                developerKey=self.credentials["token"],
+                cache_discovery=False,
+            )
+
+        creds = Credentials.from_authorized_user_info(self.credentials)
+        return build("searchconsole", "v1", credentials=creds, cache_discovery=False)
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            self._client = self._client_factory()
+        return self._client
+
+    def _fetch_range(self, site_url: str, start: date, end: date) -> RowList:
+        rows: RowList = []
+        for dimension in ("query", "page"):
+            rows.extend(self._fetch_dimension(site_url, start, end, dimension))
+        return rows
+
+    def _fetch_dimension(
+        self, site_url: str, start: date, end: date, dimension: str
+    ) -> RowList:
+        start_row = 0
+        collected: RowList = []
+        while True:
+            body = {
+                "startDate": start.isoformat(),
+                "endDate": end.isoformat(),
+                "dimensions": ["date", dimension],
+                "rowLimit": self._row_limit,
+                "startRow": start_row,
+            }
+            logger.debug(
+                "Querying GSC for %s [%s - %s] dimension=%s startRow=%s",
+                site_url,
+                body["startDate"],
+                body["endDate"],
+                dimension,
+                start_row,
+            )
+            response = self._execute_with_retry(site_url, body)
+            batch = self._convert_rows(response.get("rows", []), dimension)
+            collected.extend(batch)
+            if len(batch) < self._row_limit:
+                break
+            start_row += len(batch)
+        return collected
+
+    def _execute_with_retry(self, site_url: str, body: dict[str, Any]) -> dict[str, Any]:
+        attempt = 0
+        delay = 0.1
+        last_error: Exception | None = None
+        while attempt < 3:
+            try:
+                client = self._get_client()
+                query = client.searchanalytics().query(siteUrl=site_url, body=body)
+                return query.execute()
+            except HttpError as exc:  # pragma: no cover - exercised via retry logic
+                last_error = exc
+                status = getattr(exc.resp, "status", "unknown")
+                logger.error(
+                    "GSC request failed",
+                    extra={
+                        "site": site_url,
+                        "status": status,
+                        "body": getattr(exc, "content", b"").decode(errors="ignore"),
+                        "attempt": attempt + 1,
+                    },
+                )
+                attempt += 1
+                if attempt >= 3:
+                    raise
+                time.sleep(delay)
+                delay *= 2
+        if last_error:
+            raise last_error
+        return {}
+
+    @staticmethod
+    def _convert_rows(rows: Iterable[dict[str, Any]], dimension: str) -> RowList:
+        normalized: RowList = []
+        for row in rows:
+            keys: Sequence[str] = row.get("keys", [])
+            if len(keys) < 2:
+                continue
+            try:
+                row_date = date.fromisoformat(keys[0])
+            except ValueError:
+                logger.debug("Skipping row with invalid date: %s", keys)
+                continue
+            normalized.append(
+                SearchAnalyticsRow(
+                    date=row_date,
+                    dimension=dimension,
+                    key=keys[1],
+                    clicks=int(row.get("clicks", 0)),
+                    impressions=int(row.get("impressions", 0)),
+                    ctr=float(row.get("ctr", 0.0)),
+                    position=float(row.get("position", 0.0)),
+                )
+            )
+        return normalized
+
+    def close(self) -> None:
+        client = self._client
+        if client is not None:
+            try:
+                close = getattr(client, "close", None)
+                if callable(close):
+                    close()
+            finally:
+                self._client = None
+
+
+__all__ = ["GoogleSearchConsoleService"]

--- a/app/services/sync_runner.py
+++ b/app/services/sync_runner.py
@@ -1,0 +1,134 @@
+"""Utilities to orchestrate sync pipelines for provider integrations."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from datetime import date, timedelta
+from typing import Iterable
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.search_data import SearchData
+from app.models.site import Site
+
+from .bing_webmaster import BingWebmasterService
+from .google_search_console import GoogleSearchConsoleService
+from .types import SearchAnalyticsRow
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER_GOOGLE = "google"
+_PROVIDER_BING = "bing"
+
+
+class SyncRunner:
+    """High-level orchestration for running backfill and daily syncs."""
+
+    def __init__(
+        self,
+        db: Session,
+        *,
+        google_service_factory: type[GoogleSearchConsoleService] | None = None,
+        bing_service_factory: type[BingWebmasterService] | None = None,
+    ) -> None:
+        self.db = db
+        self._google_service_factory = google_service_factory or GoogleSearchConsoleService
+        self._bing_service_factory = bing_service_factory or BingWebmasterService
+
+    # ------------------------------------------------------------------
+    # Public entry points
+    # ------------------------------------------------------------------
+    def run_backfill(self, site: Site) -> int:
+        """Run a historical backfill for the given site."""
+
+        logger.info("Starting backfill for site %s", site.site_url)
+        rows = self._collect_rows(site, mode="backfill")
+        ingested = self._ingest(site, rows)
+        logger.info("Backfill complete for %s (rows=%s)", site.site_url, ingested)
+        return ingested
+
+    def run_daily_sync(self, site: Site, *, run_date: date | None = None) -> int:
+        """Run the daily incremental sync for the given site."""
+
+        sync_date = run_date or (date.today() - timedelta(days=1))
+        logger.info("Running daily sync for site %s on %s", site.site_url, sync_date)
+        rows = self._collect_rows(site, mode="daily", run_date=sync_date)
+        ingested = self._ingest(site, rows)
+        logger.info(
+            "Daily sync complete for %s on %s (rows=%s)", site.site_url, sync_date, ingested
+        )
+        return ingested
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _collect_rows(
+        self,
+        site: Site,
+        *,
+        mode: str,
+        run_date: date | None = None,
+    ) -> list[SearchAnalyticsRow]:
+        account = site.account
+        if account is None:
+            raise ValueError("Site does not have an associated account")
+        provider = (account.provider or "").lower()
+        credentials = account.credentials or {}
+
+        if provider == _PROVIDER_GOOGLE:
+            service = self._google_service_factory(credentials)
+        elif provider == _PROVIDER_BING:
+            service = self._bing_service_factory(credentials)
+        else:
+            raise ValueError(f"Unsupported provider: {provider}")
+
+        try:
+            if mode == "daily":
+                assert run_date is not None
+                return service.fetch_daily(site.site_url, run_date)
+            return service.fetch_backfill(site.site_url)
+        finally:
+            close = getattr(service, "close", None)
+            if callable(close):  # pragma: no branch - defensive guard
+                with suppress(Exception):
+                    close()
+
+    def _ingest(self, site: Site, rows: Iterable[SearchAnalyticsRow]) -> int:
+        total = 0
+        for row in rows:
+            self._upsert_row(site, row)
+            total += 1
+        return total
+
+    def _upsert_row(self, site: Site, row: SearchAnalyticsRow) -> None:
+        stmt = select(SearchData).where(
+            SearchData.site_id == site.id,
+            SearchData.provider == site.account.provider,
+            SearchData.date == row.date,
+            SearchData.dimension == row.dimension,
+            SearchData.key == row.key,
+        )
+        existing = self.db.execute(stmt).scalar_one_or_none()
+        if existing:
+            existing.clicks = row.clicks
+            existing.impressions = row.impressions
+            existing.ctr = row.ctr
+            existing.position = row.position
+        else:
+            record = SearchData(
+                site_id=site.id,
+                provider=site.account.provider,
+                date=row.date,
+                dimension=row.dimension,
+                key=row.key,
+                clicks=row.clicks,
+                impressions=row.impressions,
+                ctr=row.ctr,
+                position=row.position,
+            )
+            self.db.add(record)
+
+
+__all__ = ["SyncRunner"]

--- a/app/services/types.py
+++ b/app/services/types.py
@@ -1,0 +1,19 @@
+"""Shared types for search provider ingestion services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(slots=True)
+class SearchAnalyticsRow:
+    """Represents a single analytics record returned by a provider API."""
+
+    date: date
+    dimension: str
+    key: str
+    clicks: int
+    impressions: int
+    ctr: float
+    position: float

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,9 @@ celery
 redis
 pydantic[email]
 pydantic-settings
+passlib[bcrypt]
+pytest
+httpx
+google-api-python-client
+google-auth
+cryptography

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,67 @@
+import os
+import sys
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app.api.deps import get_db
+from app.core.config import settings
+from app.db.base_class import Base
+from app.db.session import engine
+from app.main import app as fastapi_app
+
+import app.models.account  # noqa: F401
+import app.models.search_data  # noqa: F401
+import app.models.site  # noqa: F401
+import app.models.sync_job  # noqa: F401
+import app.models.user  # noqa: F401
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False)
+
+
+@pytest.fixture(scope="session")
+def db_engine():
+    Base.metadata.create_all(bind=engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+    if settings.DATABASE_URL.startswith("sqlite"):
+        db_file = settings.DATABASE_URL.replace("sqlite:///", "")
+        if db_file:
+            Path(db_file).unlink(missing_ok=True)
+
+
+@pytest.fixture(scope="function")
+def db_session(db_engine) -> Generator:
+    connection = db_engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    try:
+        yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+
+
+@pytest.fixture(scope="function")
+def client(db_session):
+    def _get_test_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    fastapi_app.dependency_overrides[get_db] = _get_test_db
+    with TestClient(fastapi_app) as test_client:
+        yield test_client
+    fastapi_app.dependency_overrides.pop(get_db, None)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,148 @@
+from datetime import datetime, timezone
+
+
+def test_user_crud_flow(client):
+    response = client.post(
+        "/api/v1/users/",
+        json={"email": "user@example.com", "password": "secret"},
+    )
+    assert response.status_code == 201
+    user = response.json()
+    assert user["email"] == "user@example.com"
+
+    list_response = client.get("/api/v1/users/")
+    assert list_response.status_code == 200
+    users = list_response.json()
+    assert len(users) == 1
+
+    detail_response = client.get(f"/api/v1/users/{user['id']}")
+    assert detail_response.status_code == 200
+
+    update_response = client.put(
+        f"/api/v1/users/{user['id']}",
+        json={"email": "updated@example.com"},
+    )
+    assert update_response.status_code == 200
+    updated_user = update_response.json()
+    assert updated_user["email"] == "updated@example.com"
+
+    delete_response = client.delete(f"/api/v1/users/{user['id']}")
+    assert delete_response.status_code == 200
+
+
+def test_account_crud_flow(client):
+    user = client.post(
+        "/api/v1/users/",
+        json={"email": "owner@example.com", "password": "secret"},
+    ).json()
+
+    create_response = client.post(
+        "/api/v1/accounts/",
+        json={
+            "user_id": user["id"],
+            "provider": "Google",
+            "credentials": {"token": "abc"},
+        },
+    )
+    assert create_response.status_code == 201
+    account = create_response.json()
+    assert account["provider"] == "google"
+    assert account["user_id"] == user["id"]
+
+    list_response = client.get(f"/api/v1/accounts/?user_id={user['id']}")
+    assert list_response.status_code == 200
+    accounts = list_response.json()
+    assert len(accounts) == 1
+
+    update_response = client.put(
+        f"/api/v1/accounts/{account['id']}",
+        json={"provider": "BING"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["provider"] == "bing"
+
+    delete_response = client.delete(f"/api/v1/accounts/{account['id']}")
+    assert delete_response.status_code == 200
+
+
+def test_account_rejects_unknown_provider(client):
+    user = client.post(
+        "/api/v1/users/",
+        json={"email": "invalid-provider@example.com", "password": "secret"},
+    ).json()
+
+    response = client.post(
+        "/api/v1/accounts/",
+        json={
+            "user_id": user["id"],
+            "provider": "yahoo",
+            "credentials": {"token": "zzz"},
+        },
+    )
+    assert response.status_code == 422
+    list_response = client.get(f"/api/v1/accounts/?user_id={user['id']}")
+    assert list_response.status_code == 200
+    assert list_response.json() == []
+
+
+def test_site_and_sync_job_crud_flow(client):
+    user = client.post(
+        "/api/v1/users/",
+        json={"email": "sync@example.com", "password": "secret"},
+    ).json()
+    account = client.post(
+        "/api/v1/accounts/",
+        json={
+            "user_id": user["id"],
+            "provider": "Google",
+            "credentials": {"token": "xyz"},
+        },
+    ).json()
+
+    site_response = client.post(
+        "/api/v1/sites/",
+        json={"account_id": account["id"], "site_url": "https://example.com"},
+    )
+    assert site_response.status_code == 201
+    site = site_response.json()
+    assert site["site_url"] == "https://example.com"
+
+    sites_response = client.get(f"/api/v1/sites/?account_id={account['id']}")
+    assert sites_response.status_code == 200
+    assert len(sites_response.json()) == 1
+
+    site_update = client.put(
+        f"/api/v1/sites/{site['id']}",
+        json={"enabled": False},
+    )
+    assert site_update.status_code == 200
+    assert site_update.json()["enabled"] is False
+
+    sync_job_response = client.post(
+        "/api/v1/sync-jobs/",
+        json={
+            "site_id": site["id"],
+            "status": "pending",
+            "started_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    assert sync_job_response.status_code == 201
+    sync_job = sync_job_response.json()
+    assert sync_job["status"] == "pending"
+
+    sync_jobs_response = client.get("/api/v1/sync-jobs/?status_filter=pending")
+    assert sync_jobs_response.status_code == 200
+    assert len(sync_jobs_response.json()) == 1
+
+    sync_job_update = client.put(
+        f"/api/v1/sync-jobs/{sync_job['id']}",
+        json={"status": "completed"},
+    )
+    assert sync_job_update.status_code == 200
+    assert sync_job_update.json()["status"] == "completed"
+
+    sync_job_delete = client.delete(f"/api/v1/sync-jobs/{sync_job['id']}")
+    assert sync_job_delete.status_code == 200
+
+    site_delete = client.delete(f"/api/v1/sites/{site['id']}")
+    assert site_delete.status_code == 200

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,34 @@
+from app import crud
+from app.models.account import Account
+from app.schemas.account import AccountCreate
+from app.schemas.user import UserCreate
+
+
+def test_account_credentials_are_encrypted(db_session):
+    user = crud.user.create(
+        db_session,
+        obj_in=UserCreate(email="secure@example.com", password="secret"),
+    )
+
+    account = crud.account.create(
+        db_session,
+        obj_in=AccountCreate(
+            user_id=user.id,
+            provider="google",
+            credentials={"token": "top-secret-token"},
+        ),
+    )
+
+    stored = (
+        db_session.query(Account)
+        .filter(Account.id == account.id)
+        .one()
+    )
+
+    ciphertext = stored._credentials
+    assert isinstance(ciphertext, str)
+    assert ciphertext
+    assert ciphertext != '{"token":"top-secret-token"}'
+
+    # The public accessor should transparently decrypt the payload.
+    assert stored.credentials == {"token": "top-secret-token"}

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+
+from app.db.session import SessionLocal
+from app.models.account import Account
+from app.models.search_data import SearchData
+from app.models.site import Site
+from app.models.sync_job import SyncJob
+from app.models.user import User
+from app.services.types import SearchAnalyticsRow
+from workers.celery_app import celery_app, refresh_periodic_tasks
+from workers.tasks import run_backfill, run_daily_sync
+
+
+@pytest.fixture(autouse=True)
+def mock_provider_services(monkeypatch):
+    class DummyGoogleService:
+        def __init__(self, _: dict[str, object]) -> None:
+            self.calls: list[str] = []
+
+        def fetch_daily(self, site_url: str, run_date: date) -> list[SearchAnalyticsRow]:
+            self.calls.append("daily")
+            return [
+                SearchAnalyticsRow(
+                    date=run_date,
+                    dimension="query",
+                    key=f"kw-{site_url}",
+                    clicks=5,
+                    impressions=10,
+                    ctr=0.5,
+                    position=3.2,
+                ),
+                SearchAnalyticsRow(
+                    date=run_date,
+                    dimension="page",
+                    key=f"{site_url}/page",
+                    clicks=2,
+                    impressions=4,
+                    ctr=0.5,
+                    position=5.0,
+                ),
+            ]
+
+        def fetch_backfill(self, site_url: str) -> list[SearchAnalyticsRow]:
+            today = date.today()
+            return [
+                SearchAnalyticsRow(
+                    date=today - timedelta(days=2),
+                    dimension="query",
+                    key=f"kw-{site_url}",
+                    clicks=7,
+                    impressions=20,
+                    ctr=0.35,
+                    position=4.2,
+                ),
+                SearchAnalyticsRow(
+                    date=today - timedelta(days=1),
+                    dimension="page",
+                    key=f"{site_url}/other",
+                    clicks=1,
+                    impressions=3,
+                    ctr=0.33,
+                    position=6.0,
+                ),
+            ]
+
+        def close(self) -> None:  # pragma: no cover - compatibility shim
+            return None
+
+    class DummyBingService(DummyGoogleService):
+        pass
+
+    monkeypatch.setattr(
+        "app.services.sync_runner.GoogleSearchConsoleService",
+        DummyGoogleService,
+    )
+    monkeypatch.setattr(
+        "app.services.sync_runner.BingWebmasterService",
+        DummyBingService,
+    )
+
+
+@pytest.fixture
+def seeded_site(db_engine) -> Site:
+    session = SessionLocal()
+    try:
+        user = User(email=f"worker-{uuid4()}@example.com", password_hash="hash")
+        session.add(user)
+        session.flush()
+
+        account = Account(user_id=user.id, provider="GOOGLE", credentials={"token": "x"})
+        session.add(account)
+        session.flush()
+        session.refresh(account)
+        assert account.provider == "google"
+
+        site = Site(account_id=account.id, site_url="https://example.com", enabled=True)
+        session.add(site)
+        session.commit()
+        session.refresh(site)
+        return site
+    finally:
+        session.close()
+
+
+def test_run_daily_sync_creates_successful_job(db_engine, seeded_site) -> None:
+    result = run_daily_sync.apply(args=(seeded_site.id,))
+    assert result.get() > 0
+
+    session = SessionLocal()
+    try:
+        job = session.query(SyncJob).filter(SyncJob.site_id == seeded_site.id).one()
+        assert job.status == "succeeded"
+        assert job.finished_at is not None
+        rows = (
+            session.query(SearchData)
+            .filter(SearchData.site_id == seeded_site.id)
+            .order_by(SearchData.date.asc())
+            .all()
+        )
+        assert rows
+        assert {row.dimension for row in rows} == {"query", "page"}
+    finally:
+        session.close()
+
+
+def test_run_backfill_creates_job_record(db_engine, seeded_site) -> None:
+    result = run_backfill.apply(args=(seeded_site.id,))
+    assert result.get() > 0
+
+    session = SessionLocal()
+    try:
+        jobs = session.query(SyncJob).filter(SyncJob.site_id == seeded_site.id).all()
+        assert any(job.status == "succeeded" for job in jobs)
+        rows = (
+            session.query(SearchData)
+            .filter(SearchData.site_id == seeded_site.id)
+            .order_by(SearchData.date.asc())
+            .all()
+        )
+        assert rows
+    finally:
+        session.close()
+
+
+def test_run_daily_sync_failure_marks_job(monkeypatch, db_engine, seeded_site) -> None:
+    from app.services import sync_runner as runner_module
+
+    def fail(*_: object, **__: object) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(runner_module.SyncRunner, "run_daily_sync", fail)
+    result = run_daily_sync.apply(args=(seeded_site.id,))
+    with pytest.raises(RuntimeError):
+        result.get()
+
+    session = SessionLocal()
+    try:
+        job = session.query(SyncJob).filter(SyncJob.site_id == seeded_site.id).order_by(SyncJob.id.desc()).first()
+        assert job is not None
+        assert job.status == "failed"
+        assert "boom" in (job.error or "")
+    finally:
+        session.close()
+
+
+def test_refresh_periodic_tasks_builds_schedule(db_engine, seeded_site) -> None:
+    schedule = refresh_periodic_tasks(celery_app)
+    key = f"daily-sync-site-{seeded_site.id}"
+    assert key in schedule
+    assert schedule[key]["task"] == "workers.tasks.run_daily_sync"
+
+    # Disable the site and ensure it is removed from the schedule
+    session = SessionLocal()
+    try:
+        site = session.get(Site, seeded_site.id)
+        assert site is not None
+        site.enabled = False
+        session.add(site)
+        session.commit()
+    finally:
+        session.close()
+
+    schedule = refresh_periodic_tasks(celery_app)
+    assert key not in schedule

--- a/workers/__init__.py
+++ b/workers/__init__.py
@@ -1,0 +1,5 @@
+"""Celery worker package for the SEO data sync platform."""
+
+from .celery_app import celery_app
+
+__all__ = ["celery_app"]

--- a/workers/celery_app.py
+++ b/workers/celery_app.py
@@ -1,0 +1,54 @@
+"""Celery application and periodic schedule configuration."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from celery import Celery
+from celery.schedules import crontab
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.db.session import SessionLocal
+from app.models.site import Site
+
+celery_app = Celery("seo_sync")
+celery_app.conf.broker_url = settings.CELERY_BROKER_URL
+celery_app.conf.result_backend = settings.CELERY_RESULT_BACKEND
+celery_app.conf.task_default_queue = "seo-sync"
+celery_app.conf.timezone = settings.CELERY_TIMEZONE
+celery_app.conf.beat_schedule = {}
+celery_app.autodiscover_tasks(["workers"])
+
+
+def _enabled_sites(session: Session) -> list[Site]:
+    return session.query(Site).filter(Site.enabled.is_(True)).all()
+
+
+def refresh_periodic_tasks(app: Celery = celery_app) -> Dict[str, dict]:
+    """Rebuild the Celery beat schedule from the current site list."""
+    schedule: Dict[str, dict] = {}
+    session = SessionLocal()
+    try:
+        for site in _enabled_sites(session):
+            schedule[f"daily-sync-site-{site.id}"] = {
+                "task": "workers.tasks.run_daily_sync",
+                "schedule": crontab(
+                    hour=settings.DAILY_SYNC_HOUR,
+                    minute=settings.DAILY_SYNC_MINUTE,
+                ),
+                "args": (site.id,),
+            }
+    finally:
+        session.close()
+
+    app.conf.beat_schedule = schedule
+    return schedule
+
+
+@celery_app.on_after_configure.connect
+def setup_periodic_tasks(sender: Celery, **_: object) -> None:
+    refresh_periodic_tasks(sender)
+
+
+__all__ = ["celery_app", "refresh_periodic_tasks"]

--- a/workers/cli.py
+++ b/workers/cli.py
@@ -1,0 +1,52 @@
+"""Command-line helpers for interacting with Celery workers."""
+
+from __future__ import annotations
+
+import argparse
+
+from workers.tasks import run_backfill, run_daily_sync
+
+
+def trigger_backfill(site_id: int) -> None:
+    result = run_backfill.delay(site_id)
+    print(f"Queued backfill task for site {site_id} (task id={result.id})")
+
+
+def trigger_daily_sync(site_id: int) -> None:
+    result = run_daily_sync.delay(site_id)
+    print(f"Queued daily sync task for site {site_id} (task id={result.id})")
+
+
+def refresh_schedule() -> None:
+    from workers.celery_app import refresh_periodic_tasks
+
+    refresh_periodic_tasks()
+    print("Celery beat schedule refreshed from database state.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Celery worker utilities")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    backfill_parser = subparsers.add_parser("backfill", help="Queue a backfill task")
+    backfill_parser.add_argument("site_id", type=int)
+
+    sync_parser = subparsers.add_parser("sync", help="Queue a daily sync task")
+    sync_parser.add_argument("site_id", type=int)
+
+    subparsers.add_parser(
+        "refresh-schedule",
+        help="Reload the Celery beat schedule based on enabled sites",
+    )
+
+    args = parser.parse_args()
+    if args.command == "backfill":
+        trigger_backfill(args.site_id)
+    elif args.command == "sync":
+        trigger_daily_sync(args.site_id)
+    elif args.command == "refresh-schedule":
+        refresh_schedule()
+
+
+if __name__ == "__main__":
+    main()

--- a/workers/tasks.py
+++ b/workers/tasks.py
@@ -1,0 +1,128 @@
+"""Celery tasks that drive historical backfills and daily syncs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from celery.utils.log import get_task_logger
+from sqlalchemy.orm import Session
+
+from app.crud.sync_job import sync_job as sync_job_crud
+from app.db.session import SessionLocal
+from app.models.site import Site
+from app.schemas.sync_job import SyncJobCreate, SyncJobUpdate
+from app.services.sync_runner import SyncRunner
+
+from .celery_app import celery_app
+
+logger = get_task_logger(__name__)
+
+
+def _load_site(session: Session, site_id: int) -> Site:
+    site = session.query(Site).filter(Site.id == site_id).first()
+    if site is None:
+        raise ValueError(f"Site {site_id} does not exist")
+    if not site.enabled:
+        raise ValueError(f"Site {site_id} is disabled")
+    return site
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _create_sync_job(session: Session, site_id: int) -> int:
+    job = sync_job_crud.create(
+        session,
+        obj_in=SyncJobCreate(
+            site_id=site_id,
+            status="running",
+            started_at=_utcnow(),
+        ),
+    )
+    return job.id
+
+
+def _mark_job_succeeded(session: Session, job_id: int) -> None:
+    job = sync_job_crud.get(session, job_id)
+    if job is None:
+        return
+    sync_job_crud.update(
+        session,
+        db_obj=job,
+        obj_in=SyncJobUpdate(
+            status="succeeded",
+            finished_at=_utcnow(),
+            error=None,
+        ),
+    )
+
+
+def _mark_job_failed(job_id: int | None, *, site_id: int, error: Exception) -> None:
+    error_message = str(error)
+    session = SessionLocal()
+    try:
+        if job_id is None:
+            sync_job_crud.create(
+                session,
+                obj_in=SyncJobCreate(
+                    site_id=site_id,
+                    status="failed",
+                    started_at=_utcnow(),
+                    finished_at=_utcnow(),
+                    error=error_message,
+                ),
+            )
+        else:
+            job = sync_job_crud.get(session, job_id)
+            if job is None:
+                return
+            sync_job_crud.update(
+                session,
+                db_obj=job,
+                obj_in=SyncJobUpdate(
+                    status="failed",
+                    finished_at=_utcnow(),
+                    error=error_message,
+                ),
+            )
+    finally:
+        session.close()
+
+
+def _run_with_job(site_id: int, runner_fn: str) -> int:
+    session = SessionLocal()
+    job_id: int | None = None
+    try:
+        site = _load_site(session, site_id)
+        job_id = _create_sync_job(session, site_id)
+        runner = SyncRunner(session)
+        if runner_fn == "backfill":
+            runner.run_backfill(site)
+        else:
+            runner.run_daily_sync(site)
+        session.commit()
+        _mark_job_succeeded(session, job_id)
+        return job_id
+    except Exception as exc:  # noqa: BLE001 - propagate task failure after logging
+        session.rollback()
+        _mark_job_failed(job_id, site_id=site_id, error=exc)
+        logger.exception("%s task failed for site %s", runner_fn, site_id)
+        raise
+    finally:
+        session.close()
+
+
+@celery_app.task(name="workers.tasks.run_backfill")
+def run_backfill(site_id: int) -> int:
+    """Kick off a historical backfill for the provided site."""
+    return _run_with_job(site_id, "backfill")
+
+
+@celery_app.task(name="workers.tasks.run_daily_sync")
+def run_daily_sync(site_id: int) -> int:
+    """Run the daily incremental sync for the provided site."""
+    return _run_with_job(site_id, "daily")
+
+
+__all__ = ["run_backfill", "run_daily_sync"]


### PR DESCRIPTION
## Summary
- add a shared provider normalization helper and enforce it at the ORM and schema layers so accounts always store a supported provider value
- update API and worker tests to cover normalization behaviour and rejection of unsupported providers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfc56b0cf08325b161820a7a25bb5c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduces v1 API to manage users, accounts, sites, and sync jobs.
  * Adds Google Search Console and Bing Webmaster integrations for data sync.
  * Supports historical backfill and scheduled daily syncs.
  * Provides a CLI to trigger backfills, daily syncs, and refresh schedules.
* Security
  * Encrypts stored account credentials.
* Configuration
  * Adds settings for task scheduling, broker/backends, and encryption key.
* Documentation
  * New README with setup, running services, workers, and CLI usage.
* Tests
  * Adds end-to-end API, encryption, and worker scheduling tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->